### PR TITLE
Add options for host and proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,36 @@
 # save-page-now-api
- A wrapper for Internet Archive Wayback Machine's Save Page Now API.
+ A Python wrapper for Internet Archive Wayback Machine's Save Page Now API.
+
+## Feature
+
+* **Easy to Use:** Provides a simple interface to interact with the Save Page Now API.
+* **Customizable SPN Host and Proxy:** Allows specifying a custom SPN host and proxy settings, enabling use with services like Tor.
 
 ## Usage
 
+Send a save request to SPN:
+
 ```python
 from save_page_now_api import SavePageNowApi
-
 api = SavePageNowApi(token="XXX:YYY")
 result = api.save("https://example.com")
-
-print(result)
 """
+result:
 {
     'url': 'https://example.com',
     'job_id': 'spn2-XXXXXXXXXXXXXX'
 }
 """
+```
+
+API with Tor:
+
+```python
+proxies = {
+    "http": "schema://host:port",
+    "https": "schema://host:port",
+}
+tor_api = SavePageNowApi(token="XXX:YYY", host="https://ZZZ.onion", proxies=proxies)
 ```
 
 ## Installation

--- a/save_page_now_api/save_page_now_api.py
+++ b/save_page_now_api/save_page_now_api.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 import requests
 from requests.exceptions import JSONDecodeError
 
@@ -6,12 +8,24 @@ from .save_page_option import SavePageOption
 
 
 class SavePageNowApi:
-    DEFAULT_USER_AGENT = "https://github.com/bac0id/save-page-now-api"
+    DEFAULT_USER_AGENT = "save-page-now-api (https://github.com/bac0id/save-page-now-api)"
 
-    def __init__(self, token: str, user_agent: str = DEFAULT_USER_AGENT):
+    def __init__(
+        self,
+        *,
+        host: str = "https://web.archive.org/",
+        token: str,
+        user_agent: str = DEFAULT_USER_AGENT,
+        proxies=None,
+    ):
+        self.host = host
         self.token = token
         self.user_agent = user_agent
-        self.api_url = "https://web.archive.org/save"
+        self.proxies = proxies
+
+    def __get_save_api_url(self) -> str:
+        api_url = urljoin(self.host, "/save")
+        return api_url
 
     def __get_http_headers(self) -> dict[str, str]:
         headers = {
@@ -46,8 +60,9 @@ class SavePageNowApi:
         )
         payload = option.to_http_post_payload()
 
+        api_url = self.__get_save_api_url()
         response = requests.post(
-            url=self.api_url, headers=headers, data=payload
+            url=api_url, headers=headers, data=payload, proxies=self.proxies
         )
 
         # raise for errors

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ except FileNotFoundError:
     )
     print("WARNING: README.md not found. Using a short description.")
 
-
 setup(
     name="save-page-now-api",
     version="0.1.1",
@@ -25,9 +24,8 @@ setup(
     author_email="ji2b13y6i@mozmail.com",
     description="A Python wrapper for the Internet Archive's Save Page Now API.",
     long_description=long_description,
-    long_description_content_type="text/markdown",
     url="https://github.com/bac0id/save-page-now-api",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*", "docs*"]),
     install_requires=[
         "requests>=2.0",
     ],


### PR DESCRIPTION
Feature for #1.

Now we can set `host` and `proxies` of SPN, like this:

```python
proxies = {
    "http": "schema://host:port",
    "https": "schema://host:port",
}
tor_api = SavePageNowApi(token="XXX:YYY", host="https://ZZZ.onion", proxies=proxies)
```